### PR TITLE
feat: add  GitHub action for labeling issues and PR as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: 'Close stale issues and PRs'
+
+permissions:
+  actions: write
+  issues: write
+  pull-requests: write
+  
+on:
+  schedule:
+    - cron: "30 1 * * *" # once a day (1:30 UTC)
+  workflow_dispatch: # allow manual trigger
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          days-before-stale: 30
+          days-before-close: 5
+      


### PR DESCRIPTION
According to #79 this PR introduces a stale bot that checks once a day if there are any stale issues or PR and mark them as `stale`.

Currently it is configured to be 30 days for adding the stale label and adding the corresponding comment + 5 days before automatically closing the issue/PR.
This is meant as a starting point and might be adapted after getting the first impressions on falsely closed issues/PR. 

Remember: commenting on issues or removing the label again is always an option if there is clarity that someone is working on the issue/PR. 